### PR TITLE
The CriticTests plugin deprecated

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,7 +17,7 @@ is_trial = 1
 ; Changes release number:
 [NextRelease]
 [ExtraTests]
-[CriticTests]
+[Test::Perl::Critic]
 [PodCoverageTests]
 [PodSyntaxTests]
 [TestRelease]


### PR DESCRIPTION
Replaced by Test::Perl::Critic.
